### PR TITLE
Streamline Testsuite naming convention

### DIFF
--- a/src/components/modal/modal.spec.js
+++ b/src/components/modal/modal.spec.js
@@ -23,7 +23,7 @@ function getDummyModalComponentOptions(customOptions = {}) {
     };
 }
 
-describe('Modal spec', () => {
+describe('Component modal', () => {
     it('The modal is an object', () => {
         expect(Modal).to.be.an('object');
         expect(Modal).to.be.not.empty;

--- a/src/components/overlay/overlay.spec.js
+++ b/src/components/overlay/overlay.spec.js
@@ -27,7 +27,7 @@ function getDummyOverlayComponentOptions(customOptions = {}) {
     };
 }
 
-describe('Overlay spec', () => {
+describe('Component overlay', () => {
     it('The overlay is an object', () => {
         expect(Overlay).to.be.an('object');
         expect(Overlay).to.be.not.empty;

--- a/src/filters/background-image/background-image.spec.js
+++ b/src/filters/background-image/background-image.spec.js
@@ -1,7 +1,7 @@
 import bgImageFilter from './';
 import { expect } from 'chai';
 
-describe('bgImage filter', () => {
+describe('Filter bgImage', () => {
     it('Create style object', () => {
         const url = 'foo';
         const style = bgImageFilter(url);

--- a/src/filters/srcset/srcset.spec.js
+++ b/src/filters/srcset/srcset.spec.js
@@ -1,7 +1,7 @@
 import srcsetFilter from './';
 import { expect } from 'chai';
 
-describe('srcset filter', () => {
+describe('Filter srcset', () => {
     it('srcset with one image', () => {
         const urls = ['foo'];
         const srcset = srcsetFilter(urls);

--- a/src/mixins/bem/bem.spec.js
+++ b/src/mixins/bem/bem.spec.js
@@ -10,7 +10,7 @@ function getDummyComponentProps(mixin) {
     };
 }
 
-describe('Bem Mixin', () => {
+describe('Mixin bem', () => {
     describe('Computed properties', () => {
         it('It returns the bemRoot class properly', () => {
             const vm = new localVue(getDummyComponentProps(bemMixin('root')));

--- a/src/mixins/intersection-observer/index.spec.js
+++ b/src/mixins/intersection-observer/index.spec.js
@@ -1,0 +1,5 @@
+
+
+describe('Mixin intersection-observer', function () {
+
+});

--- a/src/mixins/scroll-lock-helper/scroll-lock-helper.spec.js
+++ b/src/mixins/scroll-lock-helper/scroll-lock-helper.spec.js
@@ -30,7 +30,7 @@ function getDummyComponentProps(customOptions = {}) { // eslint-disable-line
     };
 }
 
-describe('Scroll lock helper mixin', () => {
+describe('Mixin scroll-lock-helper', () => {
     describe('Computed properties', () => {
         it('Can read the scroll overlay flag', () => {
             expect(true).to.be.not.undefined;

--- a/src/modules/overlay/overlay-module.spec.js
+++ b/src/modules/overlay/overlay-module.spec.js
@@ -7,7 +7,7 @@ import overlayModule, { DEFAULT_CLOSING_STATE } from './';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 
-describe('Overlay spec', () => {
+describe('Vuex overlay', () => {
     describe('Overlays default export', () => {
         it('The overlay module exports properly all the vuex properties', () => {
             const props = ['namespaced', 'mutations', 'actions', 'getters', 'state'];

--- a/src/modules/scroll/scroll-module.spec.js
+++ b/src/modules/scroll/scroll-module.spec.js
@@ -6,7 +6,7 @@ import scrollModule from './';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 
-describe('Scroll spec', () => {
+describe('Vuex scroll', () => {
     describe('Scroll default export', () => {
         it('The scroll module exports properly all the vuex properties', () => {
             const props = ['namespaced', 'mutations', 'actions', 'state'];


### PR DESCRIPTION
Use a more clear namingconvention for testsuites. {TYPE}[Vuex|Filter|Component|Mixin...] {SUBJECT}[intersection-observer|srcset|Overlay]