### PR TITLE
Feature/vue ui class rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ Icon^M^M
 
 # nyc test coverage
 /reports/
-.nyc_output

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ Icon^M^M
 
 # nyc test coverage
 /reports/
+.nyc_output

--- a/src/components/accordion/accordion.vue
+++ b/src/components/accordion/accordion.vue
@@ -1,7 +1,6 @@
 <template>
     <div class="ui-accordion" :class="rootClasses">
-        <div
-                class="u-reset ui-accordion--head"
+        <div class="u-reset ui-accordion--head"
                 role="heading"
                 tabindex="0"
                 :aria-expanded="state.isOpen ? 'true' : 'false'"

--- a/src/components/form/actions/actions.spec.js
+++ b/src/components/form/actions/actions.spec.js
@@ -6,8 +6,8 @@ describe('Component actions', () => {
     it('It can handle empty actions', () => {
         const wrapper = shallowMount(UiActions, {});
 
-        expect(wrapper.findAll('.form-field--actions')).to.have.length(0);
-        expect(wrapper.find('.form-field__has-actions').exists()).to.not.be.ok;
+        expect(wrapper.findAll('.ui-form-field--actions')).to.have.length(0);
+        expect(wrapper.find('.ui-form-field__has-actions').exists()).to.not.be.ok;
     });
 
     it('It can handle custom actions', () => {
@@ -17,6 +17,6 @@ describe('Component actions', () => {
             },
         });
 
-        expect(wrapper.findAll('.form-field--action')).to.have.length(3);
+        expect(wrapper.findAll('.ui-form-field--action')).to.have.length(3);
     });
 });

--- a/src/components/form/actions/actions.vue
+++ b/src/components/form/actions/actions.vue
@@ -2,13 +2,13 @@
     import { createBemClass, DEFAULT_OPTIONS } from '../../../mixins/bem/helpers';
 
     const ROOT_CLASS = 'ui-form-field';
-    const wrappedChildClass = createBemClass({ // eslint-disable-line no-unused-vars
+    const wrappedChildClass = createBemClass({
         blockName: ROOT_CLASS,
         modifierName: '',
         elementName: 'action',
         ...DEFAULT_OPTIONS,
     });
-    const componentClass = createBemClass({ // eslint-disable-line no-unused-vars
+    const componentClass = createBemClass({
         blockName: ROOT_CLASS,
         modifierName: '',
         elementName: 'actions',

--- a/src/components/form/actions/actions.vue
+++ b/src/components/form/actions/actions.vue
@@ -1,4 +1,20 @@
 <script>
+    import { createBemClass, DEFAULT_OPTIONS } from '../../../mixins/bem/helpers';
+
+    const ROOT_CLASS = 'ui-form-field';
+    const wrappedChildClass = createBemClass({ // eslint-disable-line no-unused-vars
+        blockName: ROOT_CLASS,
+        modifierName: '',
+        elementName: 'action',
+        ...DEFAULT_OPTIONS,
+    });
+    const componentClass = createBemClass({ // eslint-disable-line no-unused-vars
+        blockName: ROOT_CLASS,
+        modifierName: '',
+        elementName: 'actions',
+        ...DEFAULT_OPTIONS,
+    });
+
     export default {
         functional: true,
         render(h, { children }) {
@@ -7,10 +23,10 @@
             }
 
             const wrappedChildren = children.map(action => {
-                return h('span', { class: 'form-field--action' }, [action]);
+                return h('span', { class: wrappedChildClass }, [action]);
             });
 
-            return h('div', { class: 'form-field--actions' }, wrappedChildren);
+            return h('div', { class: componentClass }, wrappedChildren);
         },
     };
 </script>

--- a/src/components/form/actions/actions.vue
+++ b/src/components/form/actions/actions.vue
@@ -1,19 +1,9 @@
 <script>
     import { createBemClass, DEFAULT_OPTIONS } from '../../../mixins/bem/helpers';
 
-    const ROOT_CLASS = 'ui-form-field';
-    const wrappedChildClass = createBemClass({
-        blockName: ROOT_CLASS,
-        modifierName: '',
-        elementName: 'action',
-        ...DEFAULT_OPTIONS,
-    });
-    const componentClass = createBemClass({
-        blockName: ROOT_CLASS,
-        modifierName: '',
-        elementName: 'actions',
-        ...DEFAULT_OPTIONS,
-    });
+    const CLASS_CONFIG = { blockName: 'ui-form-field', modifierName: '', ...DEFAULT_OPTIONS };
+    const wrappedChildClass = createBemClass({ elementName: 'action', ...CLASS_CONFIG });
+    const componentClass = createBemClass({ elementName: 'actions', ...CLASS_CONFIG });
 
     export default {
         functional: true,

--- a/src/components/form/checkbox/checkbox.spec.js
+++ b/src/components/form/checkbox/checkbox.spec.js
@@ -26,7 +26,7 @@ describe('Component checkbox', () => {
             },
         });
 
-        expect(wrapper.find('.form-field--action').exists()).to.not.ok;
+        expect(wrapper.find('.ui-form-field--action').exists()).to.not.ok;
         expect(wrapper.find('input').exists()).to.be.ok;
         expect(wrapper.find('.label').exists()).to.be.ok;
     });
@@ -68,7 +68,7 @@ describe('Component checkbox', () => {
         expect(input.value).to.be.equal('foo');
         expect(input.checked).to.be.ok;
         expect(wrapper.vm.isChecked).to.be.ok;
-        expect(wrapper.find('.form-field__is-checked').exists()).to.be.ok;
+        expect(wrapper.find('.ui-form-field__is-checked').exists()).to.be.ok;
     });
 
     it('It can dispatch the onchange events listened from the outside', done => {

--- a/src/components/form/checkbox/checkbox.vue
+++ b/src/components/form/checkbox/checkbox.vue
@@ -1,20 +1,20 @@
 <template>
-    <div class="form-field form-field__bool form-field__checkbox"
+    <div class="ui-form-field ui-form-field__bool ui-form-field__checkbox"
             :class="[...rootClasses, bemIf(isChecked, 'is-checked')]">
         <label>
             <input type="checkbox"
-                    class="form-field--input"
+                    class="ui-form-field--input"
                     :value="value"
                     v-bind="$attrs"
                     @change="onChange"
                     v-on="$listeners">
-            <div class="form-field--label-wrap">
-                <span class="form-field--box">
+            <div class="ui-form-field--label-wrap">
+                <span class="ui-form-field--box">
                     <slot mame="icon">
-                        <ui-icon class="form-field--box-icon" symbol="checkmark" size="small"/>
+                        <ui-icon class="ui-form-field--box-icon" symbol="checkmark" size="small"/>
                     </slot>
                 </span>
-                <div class="form-field--label">
+                <div class="ui-form-field--label">
                     <slot name="label"/>
                 </div>
             </div>
@@ -35,7 +35,7 @@
             UiIcon,
         },
         mixins: [
-            bemMixin('form-field'),
+            bemMixin('ui-form-field'),
             rootClassesMixin,
             isCheckedMixin,
             hasErrorsPropsMixin,

--- a/src/components/form/input/input.spec.js
+++ b/src/components/form/input/input.spec.js
@@ -19,11 +19,11 @@ describe('Component input', () => {
             },
         });
 
-        expect(wrapper.find('.form-field--action').exists()).to.not.ok;
+        expect(wrapper.find('.ui-form-field--action').exists()).to.not.ok;
         expect(wrapper.find('input').exists()).to.be.ok;
-        expect(wrapper.find('.form-field--input-container').element.getAttribute('data-action-count')).to.be.equal('0');
-        expect(wrapper.find('.form-field__is-filled').exists()).to.be.ok;
-        expect(wrapper.find('.form-field__has-actions').exists()).to.be.not.ok;
+        expect(wrapper.find('.ui-form-field--input-container').element.getAttribute('data-action-count')).to.be.equal('0');
+        expect(wrapper.find('.ui-form-field__is-filled').exists()).to.be.ok;
+        expect(wrapper.find('.ui-form-field__has-actions').exists()).to.be.not.ok;
     });
 
     it('It can render the the slots properly', () => {
@@ -39,7 +39,7 @@ describe('Component input', () => {
 
         expect(wrapper.contains('.custom-label')).to.be.ok;
         expect(wrapper.contains('.messages')).to.be.ok;
-        expect(wrapper.contains('.form-field--action')).to.be.not.ok;
+        expect(wrapper.contains('.ui-form-field--action')).to.be.not.ok;
     });
 
     it('It can handle empty actions', () => {
@@ -52,8 +52,8 @@ describe('Component input', () => {
             },
         });
 
-        expect(wrapper.findAll('.form-field--actions')).to.have.length(0);
-        expect(wrapper.find('.form-field__has-actions').exists()).to.not.be.ok;
+        expect(wrapper.findAll('.ui-form-field--actions')).to.have.length(0);
+        expect(wrapper.find('.ui-form-field__has-actions').exists()).to.not.be.ok;
     });
 
     it('It can handle custom actions', () => {
@@ -69,7 +69,7 @@ describe('Component input', () => {
             },
         });
 
-        expect(wrapper.find('.form-field--input-container').element.getAttribute('data-action-count')).to.be.equal('3');
-        expect(wrapper.find('.form-field__has-actions').exists()).to.be.ok;
+        expect(wrapper.find('.ui-form-field--input-container').element.getAttribute('data-action-count')).to.be.equal('3');
+        expect(wrapper.find('.ui-form-field__has-actions').exists()).to.be.ok;
     });
 });

--- a/src/components/form/input/input.vue
+++ b/src/components/form/input/input.vue
@@ -1,16 +1,16 @@
 <template>
-    <div class="form-field form-field__input" :class="rootClasses">
+    <div class="ui-form-field ui-form-field__input" :class="rootClasses">
         <label>
-            <span class="form-field--title-label" v-if="!hasFloatingLabel && $scopedSlots.label">
+            <span class="ui-form-field--title-label" v-if="!hasFloatingLabel && $scopedSlots.label">
                 <slot name="label"/>
             </span>
-            <div class="form-field--input-container" :data-action-count="actionCount">
-                <span class="form-field--floating-label" v-if="hasFloatingLabel && $scopedSlots.label">
+            <div class="ui-form-field--input-container" :data-action-count="actionCount">
+                <span class="ui-form-field--floating-label" v-if="hasFloatingLabel && $scopedSlots.label">
                     <slot name="label"/>
                 </span>
                 <slot name="input">
                     <input v-model="currentValue"
-                            class="form-field--input"
+                            class="ui-form-field--input"
                             v-bind="$attrs"
                             @focus="onFocus"
                             @blur="onBlur"
@@ -40,7 +40,7 @@
             UiActions,
         },
         mixins: [
-            bemMixin('form-field'),
+            bemMixin('ui-form-field'),
             focusBehaviourMixin,
             rootClassesMixin,
             floatingLabelPropsMixin,

--- a/src/components/form/radio/radio.spec.js
+++ b/src/components/form/radio/radio.spec.js
@@ -22,7 +22,7 @@ describe('Component radio', () => {
             },
         });
 
-        expect(wrapper.find('.form-field--action').exists()).to.not.ok;
+        expect(wrapper.find('.ui-form-field--action').exists()).to.not.ok;
         expect(wrapper.find('input').exists()).to.be.ok;
         expect(wrapper.find('.label').exists()).to.be.ok;
     });
@@ -62,7 +62,7 @@ describe('Component radio', () => {
         expect(input.value).to.be.equal('foo');
         expect(input.checked).to.be.ok;
         expect(wrapper.vm.isChecked).to.be.ok;
-        expect(wrapper.find('.form-field__is-checked').exists()).to.be.ok;
+        expect(wrapper.find('.ui-form-field__is-checked').exists()).to.be.ok;
     });
 
     it('It can dispatch the onchange events listened from the outside', done => {

--- a/src/components/form/radio/radio.vue
+++ b/src/components/form/radio/radio.vue
@@ -1,22 +1,22 @@
 <template>
-    <div class="form-field form-field__bool form-field__radio"
+    <div class="ui-form-field ui-form-field__bool ui-form-field__radio"
             :class="[...rootClasses, bemIf(isChecked, 'is-checked')]">
         <label>
             <input type="radio"
-                    class="form-field--input"
+                    class="ui-form-field--input"
                     v-bind="$attrs"
                     :value="value"
                     @change="onChange"
                     v-on="$listeners">
-            <div class="form-field--label-wrap">
-                <span class="form-field--box">
+            <div class="ui-form-field--label-wrap">
+                <span class="ui-form-field--box">
                     <slot mame="icon">
-                        <span class="form-field--box">
-                            <span class="form-field--box-icon"/>
+                        <span class="ui-form-field--box">
+                            <span class="ui-form-field--box-icon"/>
                         </span>
                     </slot>
                 </span>
-                <div class="form-field--label">
+                <div class="ui-form-field--label">
                     <slot name="label"/>
                 </div>
             </div>
@@ -33,7 +33,7 @@
 
     export default {
         mixins: [
-            bemMixin('form-field'),
+            bemMixin('ui-form-field'),
             rootClassesMixin,
             isCheckedMixin,
             hasErrorsPropsMixin,

--- a/src/components/form/select/select.spec.js
+++ b/src/components/form/select/select.spec.js
@@ -26,10 +26,10 @@ describe('Component select', () => {
             },
         });
 
-        expect(wrapper.find('.form-field--action').exists()).to.ok;
+        expect(wrapper.find('.ui-form-field--action').exists()).to.ok;
         expect(wrapper.find('select').exists()).to.be.ok;
         expect(wrapper.find('.label').exists()).to.be.ok;
-        expect(wrapper.find('.form-field--input-container').element.getAttribute('data-action-count')).to.be.equal('1');
+        expect(wrapper.find('.ui-form-field--input-container').element.getAttribute('data-action-count')).to.be.equal('1');
     });
 
     it('It can render all the options provided', () => {

--- a/src/components/form/select/select.vue
+++ b/src/components/form/select/select.vue
@@ -1,12 +1,12 @@
 <template>
-    <div class="form-field form-field__input form-field__select" :class="rootClasses">
+    <div class="ui-form-field ui-form-field__input ui-form-field__select" :class="rootClasses">
         <label>
-            <div class="form-field--title-label" v-if="$scopedSlots.label">
+            <div class="ui-form-field--title-label" v-if="$scopedSlots.label">
                 <slot name="label"/>
             </div>
-            <div class="form-field--input-container" :data-action-count="actionCount || 1">
+            <div class="ui-form-field--input-container" :data-action-count="actionCount || 1">
                 <select v-model="currentValue"
-                        class="form-field--input"
+                        class="ui-form-field--input"
                         v-bind="$attrs"
                         @focus="onFocus"
                         @blur="onBlur"
@@ -40,7 +40,7 @@
             UiActions,
         },
         mixins: [
-            bemMixin('form-field'),
+            bemMixin('ui-form-field'),
             focusBehaviourMixin,
             rootClassesMixin,
             hasErrorsPropsMixin,

--- a/src/components/form/textarea/textarea.spec.js
+++ b/src/components/form/textarea/textarea.spec.js
@@ -23,10 +23,10 @@ describe('Component textarea', () => {
             },
         });
 
-        expect(wrapper.find('.form-field--action').exists()).to.not.ok;
+        expect(wrapper.find('.ui-form-field--action').exists()).to.not.ok;
         expect(wrapper.find('textarea').exists()).to.be.ok;
-        expect(wrapper.find('.form-field--input-container').element.getAttribute('data-action-count')).to.be.equal('0');
-        expect(wrapper.find('.form-field__is-filled').exists()).to.be.ok;
+        expect(wrapper.find('.ui-form-field--input-container').element.getAttribute('data-action-count')).to.be.equal('0');
+        expect(wrapper.find('.ui-form-field__is-filled').exists()).to.be.ok;
     });
 
     it('It increases the height of the textarea properly', done => {
@@ -80,7 +80,7 @@ describe('Component textarea', () => {
 
         expect(wrapper.contains('.custom-label')).to.be.ok;
         expect(wrapper.contains('.messages')).to.be.ok;
-        expect(wrapper.contains('.form-field--action')).to.be.not.ok;
+        expect(wrapper.contains('.ui-form-field--action')).to.be.not.ok;
     });
 
     it('It can handle custom actions', () => {
@@ -96,7 +96,7 @@ describe('Component textarea', () => {
             },
         });
 
-        expect(wrapper.findAll('.form-field--action')).to.have.length(1);
-        expect(wrapper.find('.form-field--input-container').element.getAttribute('data-action-count')).to.be.equal('1');
+        expect(wrapper.findAll('.ui-form-field--action')).to.have.length(1);
+        expect(wrapper.find('.ui-form-field--input-container').element.getAttribute('data-action-count')).to.be.equal('1');
     });
 });

--- a/src/components/form/textarea/textarea.vue
+++ b/src/components/form/textarea/textarea.vue
@@ -1,16 +1,16 @@
 <template>
-    <div class="form-field form-field__input form-field__textarea" :class="rootClasses">
+    <div class="ui-form-field ui-form-field__input ui-form-field__textarea" :class="rootClasses">
         <label>
-            <span class="form-field--title-label" v-if="!hasFloatingLabel && $scopedSlots.label">
+            <span class="ui-form-field--title-label" v-if="!hasFloatingLabel && $scopedSlots.label">
                 <slot name="label"/>
             </span>
-            <div class="form-field--input-container" :data-action-count="actionCount">
-                <span class="form-field--floating-label" v-if="hasFloatingLabel && $scopedSlots.label">
+            <div class="ui-form-field--input-container" :data-action-count="actionCount">
+                <span class="ui-form-field--floating-label" v-if="hasFloatingLabel && $scopedSlots.label">
                     <slot name="label"/>
                 </span>
                 <textarea v-model="currentValue"
                         v-bind="$attrs"
-                        class="form-field--input"
+                        class="ui-form-field--input"
                         ref="input"
                         @focus="onFocus"
                         @blur="onBlur"
@@ -42,7 +42,7 @@
             UiActions,
         },
         mixins: [
-            bemMixin('form-field'),
+            bemMixin('ui-form-field'),
             rootClassesMixin,
             currentValueMixin,
             floatingLabelPropsMixin,

--- a/src/components/icon/icon.vue
+++ b/src/components/icon/icon.vue
@@ -1,5 +1,5 @@
 <template>
-    <svg class="icon"
+    <svg class="ui-icon"
             tabindex="-1"
             focusable="false"
             :class="[rootClasses]">
@@ -16,7 +16,7 @@
 
     export default {
         mixins: [
-            bemMixin('icon'),
+            bemMixin('ui-icon'),
         ],
         props: {
             symbol: {

--- a/src/components/intersection-observer/intersection-observer.vue
+++ b/src/components/intersection-observer/intersection-observer.vue
@@ -2,7 +2,9 @@
     import intersectionObserverMixin from '../../mixins/intersection-observer';
 
     export default {
-        mixins: [intersectionObserverMixin],
+        mixins: [
+            intersectionObserverMixin,
+        ],
 
         props: {
             thresholdMin: {

--- a/src/components/scroll-reveal/scroll-reveal.vue
+++ b/src/components/scroll-reveal/scroll-reveal.vue
@@ -9,7 +9,9 @@
     import bemMixin from '../../mixins/bem';
 
     export default {
-        mixins: [bemMixin('')],
+        mixins: [
+            bemMixin(''),
+        ],
         props: {
             elementClass: {
                 type: String,

--- a/src/mixins/bem/helpers.js
+++ b/src/mixins/bem/helpers.js
@@ -55,8 +55,8 @@ export function mapFacets(blockName, facets, options = DEFAULT_OPTIONS) {
 
     // Apply multiple facets by using an array
     const result = facets
-        .map(modifierName => createBemClass({ blockName, modifierName, ...rest }))
-        .filter(Boolean);
+        .filter(Boolean)
+        .map(modifierName => createBemClass({ blockName, modifierName, ...rest }));
 
     // As `facet` can still be an empty string, we'll provide a base facet as a fallback
     if (!result.length) {
@@ -76,7 +76,7 @@ export function createBemClass(bemClassParts) {
 
     const elementPart = elementName ? `${ bemElementMarker }${ elementName }` : '';
     const modifierPart = modifierName ? `${ bemModifierMarker }${ modifierName }` : '';
-    return modifierPart ? `${ blockName }${ elementPart }${ modifierPart }` : '';
+    return `${ blockName }${ elementPart }${ modifierPart }`;
 }
 
 

--- a/src/mixins/bem/index.js
+++ b/src/mixins/bem/index.js
@@ -25,6 +25,8 @@ export default function bemMixin(bemRoot, config) {
         },
         methods: {
             bemAdd(modifierName, elementName, rootName) {
+                if (!modifierName) { return ''; }
+
                 const blockName = rootName || this.bemRoot;
                 return createBemClass({ blockName, modifierName, elementName, ...options });
             },

--- a/src/mixins/intersection-observer/index.js
+++ b/src/mixins/intersection-observer/index.js
@@ -16,21 +16,24 @@ export default {
          * @param {boolean} isIntersecting - intersection identifier
          * @param {IntersectionObserverEntry} entry - Intersection element
          */
-        onIntersect(isIntersecting, entry) { // eslint-disable-line no-unused-vars
+        // eslint-disable-next-line no-unused-vars
+        onIntersect(isIntersecting, entry) {
         },
 
         /**
          * Handle when element enters viewport
          * @param {IntersectionObserverEntry} entry - intersection entry
          */
-        onIntersectEnter(entry) { // eslint-disable-line no-unused-vars
+        // eslint-disable-next-line no-unused-vars
+        onIntersectEnter(entry) {
         },
 
         /**
          * Handle when element leaves viewport
          * @param {IntersectionObserverEntry} entry - intersection entry
          */
-        onIntersectLeave(entry) { // eslint-disable-line no-unused-vars
+        // eslint-disable-next-line no-unused-vars
+        onIntersectLeave(entry) {
         },
 
         /**


### PR DESCRIPTION
This is the last change before we are ready for a `@2.0.0` release.

- Refactor all component classes with a prefix of `ui` if not already present
- Minor change to a bem method