### PR TITLE
Allow for a target height instead of a zero height collapsible

### DIFF
--- a/src/components/accordion/accordion.vue
+++ b/src/components/accordion/accordion.vue
@@ -39,6 +39,10 @@
                 type: Boolean,
                 default: false,
             },
+            targetHeight: {
+                type: Number,
+                default: 0,
+            },
         },
         data() {
             return {
@@ -78,7 +82,7 @@
                 // NOTE: Make the accordion animations smooth on any browser
                 if (!this.state.isOpen) {
                     forceReflow(body);
-                    body.style.maxHeight = '0px';
+                    body.style.maxHeight = `${ this.targetHeight }px`;
                 }
 
                 this.$emit('change', this.state.isOpen);


### PR DESCRIPTION
Allow for a target height when closed instead of always closing to `0px`